### PR TITLE
nthperm! argument checking

### DIFF
--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -133,15 +133,15 @@ done(p::MultiSetPermutations, s) =
 
 "In-place version of nthperm."
 function nthperm!(a::AbstractVector, k::Integer)
-    k -= 1 # make k 1-indexed
-    k < 0 && throw(ArgumentError("permutation k must be ≥ 0, got $k"))
     n = length(a)
     n == 0 && return a
-    f = factorial(oftype(k, n-1))
+    f = factorial(oftype(k, n))
+    0 < k <= f || throw(ArgumentError("permutation k must satisfy 0 < k ≤ $f, got $k"))
+    k -= 1 # make k 1-indexed
     for i=1:n-1
+        f = div(f, n - i + 1)
         j = div(k, f) + 1
         k = k % f
-        f = div(f, n-i)
 
         j = j+i-1
         elt = a[j]

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -39,7 +39,17 @@ end
 #Euler Problem #24
 @test nthperm!([0:9;],1000000) == [2,7,8,3,9,1,5,4,6,0]
 
-@test nthperm([0,1,2],3) == [1,0,2]
+@test_throws ArgumentError nthperm([0, 1, 2], 0)
+@test nthperm([0, 1, 2], 1) == [0, 1, 2]
+@test nthperm([0, 1, 2], 3) == [1, 0, 2]
+@test nthperm([0, 1, 2], 6) == [2, 1, 0]
+@test_throws ArgumentError nthperm([0, 1, 2], 7)
+
+@test_throws ArgumentError nthperm([0:20;], big(0))
+@test nthperm([0:20;], big(1)) == [0:20;]
+@test nthperm([0:20;], factorial(big(20))) == [0; 20:-1:1]
+@test nthperm([0:20;], factorial(big(21))) == [20:-1:0;]
+@test_throws ArgumentError nthperm([0:20;], factorial(big(21)) + 1)
 
 @test_throws ArgumentError parity([0])
 @test_throws ArgumentError parity([1,2,3,3])


### PR DESCRIPTION
When calling `nthperm([0], 0)` I got

```
ERROR: ArgumentError: permutation k must be ≥ 0, got -1
```

which is due to the fact that `k -= 1 # make k 1-indexed` was executed before the bounds check. I changed the order so that the error now reports "got 0". 

Also, I added a check for the upper bound as well, to prevent something like `nthperm([1, 2], 3)` from raising a confusing `BoundsError`. Since we need to compute the factorial anyway, this is not much different from before. However, because we need `n!` instead of `(n - 1)!` for this, now `nthperm([1:21;], 1)` fails with an `OverflowError` where previously it did not. (Of course, `nthperm([1:21;], big(1))` still works.)

I personally think that's fine, what do you think? Maybe `nthperm` should automatically use `BigInt`s when `length(a) > 20`?
