### PR TITLE
Make permutations type-stable

### DIFF
--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -36,13 +36,13 @@ end
 start(p::Permutations) = [1:length(p.a);]
 next(p::Permutations, s) = nextpermutation(p.a, p.t ,s)
 
-function nextpermutation(m, t, s)
+function nextpermutation(m, t, state)
+    s = copy(state)
     perm = [m[s[i]] for i in 1:t]
     n = length(s)
     if t <= 0
         return(perm, [n+1])
     end
-    s = copy(s)
     if t < n
         j = t + 1
         while j <= n &&  s[t] >= s[j]; j+=1; end

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -19,6 +19,8 @@ using Base.Test
 @test collect(permutations("", 0)) == Any[Char[]]
 @test collect(permutations("", -1)) == Any[]
 
+@inferred first(permutations("abc", 2))
+
 # multiset_permutations
 @test collect(multiset_permutations("aabc", 5)) == Any[]
 @test collect(multiset_permutations("aabc", 2)) == Any[['a','a'],['a','b'], ['a','c'],['b','a'],


### PR DESCRIPTION
For some reason, Julia can't infer the return type of the `next` method for `permutations`. This is just a very small change that fixes this issue. 

Before:
```
julia> @benchmark collect(permutations(1:10, 3))
BenchmarkTools.Trial: 
  memory estimate:  433.48 kb
  allocs estimate:  10085
  --------------
  minimum time:     749.489 μs (0.00% GC)
  median time:      770.428 μs (0.00% GC)
  mean time:        817.017 μs (4.68% GC)
  maximum time:     3.858 ms (78.25% GC)
  --------------
  samples:          6117
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

After:
```
julia> @benchmark collect(permutations(1:10, 3))
BenchmarkTools.Trial: 
  memory estimate:  275.95 kb
  allocs estimate:  4324
  --------------
  minimum time:     90.095 μs (0.00% GC)
  median time:      97.903 μs (0.00% GC)
  mean time:        121.701 μs (17.90% GC)
  maximum time:     3.727 ms (95.66% GC)
  --------------
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```