### PR TITLE
Make partitions type-stable

### DIFF
--- a/test/partitions.jl
+++ b/test/partitions.jl
@@ -11,6 +11,16 @@ using Base.Test
 @test collect(partitions([1,2,3,4],1)) == Any[Any[[1, 2, 3, 4]]]
 @test collect(partitions([1,2,3,4],5)) == []
 
+@inferred first(partitions(4))
+@inferred first(partitions(8,3))
+@inferred first(partitions([1,2,3]))
+@inferred first(partitions([1,2,3,4],3))
+
+@test isa(collect(partitions(4)), Vector{Vector{Int}})
+@test isa(collect(partitions(8,3)), Vector{Vector{Int}})
+@test isa(collect(partitions([1,2,3])), Vector{Vector{Vector{Int}}})
+@test isa(collect(partitions([1,2,3,4], 3)), Vector{Vector{Vector{Int}}})
+
 @test length(partitions(0)) == 1
 @test length(partitions(-1)) == 0
 @test length(collect(partitions(30))) == length(partitions(30))


### PR DESCRIPTION
This PR works around a few inference problems in Julia, fixes some type-instabilities, and adds an `eltype` method for each `*Partitions` type.  It is partly influenced by https://github.com/JuliaMath/Combinatorics.jl/pull/33 but also improves all other `partitions` iterators.

Before:
```
@benchmark(collect(partitions(4))) = BenchmarkTools.Trial: 
  memory estimate:  832.00 bytes
  allocs estimate:  12
  --------------
  minimum time:     310.097 ns (0.00% GC)
  median time:      331.508 ns (0.00% GC)
  mean time:        396.104 ns (14.28% GC)
  maximum time:     18.240 μs (96.06% GC)
  --------------
  samples:          10000
  evals/sample:     238
  time tolerance:   5.00%
  memory tolerance: 1.00%

@benchmark(collect(partitions(8,3))) = BenchmarkTools.Trial: 
  memory estimate:  3.25 kb
  allocs estimate:  71
  --------------
  minimum time:     14.790 μs (0.00% GC)
  median time:      15.744 μs (0.00% GC)
  mean time:        16.236 μs (1.56% GC)
  maximum time:     2.607 ms (97.31% GC)
  --------------
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

@benchmark(collect(partitions([1,2,3]))) = BenchmarkTools.Trial: 
  memory estimate:  3.20 kb
  allocs estimate:  60
  --------------
  minimum time:     2.251 μs (0.00% GC)
  median time:      2.352 μs (0.00% GC)
  mean time:        2.724 μs (10.99% GC)
  maximum time:     275.565 μs (97.45% GC)
  --------------
  samples:          10000
  evals/sample:     9
  time tolerance:   5.00%
  memory tolerance: 1.00%

@benchmark(collect(partitions([1,2,3,4],3))) = BenchmarkTools.Trial: 
  memory estimate:  6.78 kb
  allocs estimate:  150
  --------------
  minimum time:     19.758 μs (0.00% GC)
  median time:      21.035 μs (0.00% GC)
  mean time:        22.235 μs (3.80% GC)
  maximum time:     3.308 ms (98.42% GC)
  --------------
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%


```
After:
```
@benchmark(collect(partitions(4))) = BenchmarkTools.Trial: 
  memory estimate:  832.00 bytes
  allocs estimate:  12
  --------------
  minimum time:     307.511 ns (0.00% GC)
  median time:      328.432 ns (0.00% GC)
  mean time:        394.806 ns (14.64% GC)
  maximum time:     7.811 μs (93.69% GC)
  --------------
  samples:          10000
  evals/sample:     266
  time tolerance:   5.00%
  memory tolerance: 1.00%

@benchmark(collect(partitions(8,3))) = BenchmarkTools.Trial: 
  memory estimate:  1.03 kb
  allocs estimate:  11
  --------------
  minimum time:     320.004 ns (0.00% GC)
  median time:      351.670 ns (0.00% GC)
  mean time:        431.888 ns (16.46% GC)
  maximum time:     9.519 μs (93.88% GC)
  --------------
  samples:          10000
  evals/sample:     233
  time tolerance:   5.00%
  memory tolerance: 1.00%

@benchmark(collect(partitions([1,2,3]))) = BenchmarkTools.Trial: 
  memory estimate:  3.20 kb
  allocs estimate:  60
  --------------
  minimum time:     990.700 ns (0.00% GC)
  median time:      1.079 μs (0.00% GC)
  mean time:        1.479 μs (22.27% GC)
  maximum time:     282.089 μs (98.64% GC)
  --------------
  samples:          10000
  evals/sample:     10
  time tolerance:   5.00%
  memory tolerance: 1.00%

@benchmark(collect(partitions([1,2,3,4],3))) = BenchmarkTools.Trial: 
  memory estimate:  4.59 kb
  allocs estimate:  89
  --------------
  minimum time:     1.719 μs (0.00% GC)
  median time:      1.817 μs (0.00% GC)
  mean time:        2.461 μs (19.04% GC)
  maximum time:     300.608 μs (98.19% GC)
  --------------
  samples:          10000
  evals/sample:     10
  time tolerance:   5.00%
  memory tolerance: 1.00%

```