### PR TITLE
Workaround box created by closure lowering

### DIFF
--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -36,13 +36,13 @@ end
 start(p::Permutations) = [1:length(p.a);]
 next(p::Permutations, s) = nextpermutation(p.a, p.t ,s)
 
-function nextpermutation(m, t, s)
-    perm = [m[s[i]] for i in 1:t]
-    n = length(s)
+function nextpermutation(m, t, state)
+    perm = [m[state[i]] for i in 1:t]
+    n = length(state)
     if t <= 0
         return(perm, [n+1])
     end
-    s = copy(s)
+    s = copy(state)
     if t < n
         j = t + 1
         while j <= n &&  s[t] >= s[j]; j+=1; end

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -19,6 +19,8 @@ using Base.Test
 @test collect(permutations("", 0)) == Any[Char[]]
 @test collect(permutations("", -1)) == Any[]
 
+@inferred first(permutations("abc", 2))
+
 # multiset_permutations
 @test collect(multiset_permutations("aabc", 5)) == Any[]
 @test collect(multiset_permutations("aabc", 2)) == Any[['a','a'],['a','b'], ['a','c'],['b','a'],


### PR DESCRIPTION
by enclosing the comprehension in a `let`.

There are a few other comprehensions that might have this issue in this file but this one should be the hottest and the easiest to workaround.

This should fix the performance issue in https://github.com/JuliaLang/julia/issues/19402. Seems to work on both 0.5 and master.
