### PR TITLE
Fixes for 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: julia
 os:
     - linux
 julia:
+    - 0.5
     - nightly
 sudo: false
 notifications:
@@ -12,4 +13,3 @@ script:
     - julia -e 'Pkg.test("Combinatorics", coverage=true)'
 after_success:
     - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("Combinatorics")); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(process_folder())'
-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.5-
+julia 0.5
+Compat 0.9.4
 Polynomials
 Iterators

--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -110,7 +110,7 @@ function next(C::CoolLexCombinations, S::CoolLexIterState)
     R3 = S.R3
 
     R0 = R3 & (R3 + 1)
-    R1 = R0 $ (R0 - 1)
+    R1 = xor(R0, R0 - 1)
     R0 = R1 + 1
     R1 &= R3
     R0 = max((R0 & R3) - 1, 0)

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -198,12 +198,12 @@ function levicivita{T<:Integer}(p::AbstractVector{T})
 
     while cycles + flips < n
         first = findnext(todo, first)
-        (todo[first] $= true) && return 0
+        (todo[first] = !todo[first]) && return 0
         j = p[first]
         (0 < j <= n) || return 0
         cycles += 1
         while j ≠ first
-            (todo[j] $= true) && return 0
+            (todo[j] = !todo[j]) && return 0
             j = p[j]
             (0 < j <= n) || return 0
             flips += 1


### PR DESCRIPTION
* Enable 0.5 on travis
* Require 0.5 release and add missing Compat dependency
* Fix depwarn for `$`

There are other depwarns that requires changes in `Compat` (or other packages) (`num` and possibly `filter`).
