### PR TITLE
nthperm(): Replace one `%=` by a `-= remainder * divisor` computed earlier

### DIFF
--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -152,9 +152,9 @@ function nthperm!(a::AbstractVector, k::Integer)
     0 < k <= f || throw(ArgumentError("permutation k must satisfy 0 < k ≤ $f, got $k"))
     k -= 1 # make k 1-indexed
     for i=1:n-1
+        f ÷= n - i + 1
         j = k ÷ f
         k -= j * f
-        f ÷= n - i
         j += i
         elt = a[j]
         for d = j:-1:i+1

--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -139,11 +139,11 @@ function nthperm!(a::AbstractVector, k::Integer)
     n == 0 && return a
     f = factorial(oftype(k, n-1))
     for i=1:n-1
-        j = div(k, f) + 1
-        k = k % f
-        f = div(f, n-i)
+        j = k ÷ f
+        k -= j * f
+        f ÷= n - i
 
-        j = j+i-1
+        j += i
         elt = a[j]
         for d = j:-1:i+1
             a[d] = a[d-1]


### PR DESCRIPTION
This is a tiny rewrite that makes `nthperm!()` a little faster, by about 15% or so.  The speed results from replacing an effective `k = k ÷ f` by `k = k - j * f`, where `j` has been computed in an earlier `%`.   

(Incidentally, this kind of code could benefit from a generic function `divisor, remainder = integer_divide(num, denom)`)

Further some small cosmetic changes, and an unnecessary `+1-1` removal for `j`.