### PR TITLE
Allow immutable collections in nthperm

### DIFF
--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -172,7 +172,7 @@ end
 
 Compute the `k`th lexicographic permutation of the vector `a`.
 """
-nthperm(a::AbstractVector, k::Integer) = nthperm!(copy(a), k)
+nthperm(a::AbstractVector, k::Integer) = nthperm!(collect(a), k)
 
 """
     nthperm(p)

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -44,6 +44,9 @@ end
 
 @test nthperm([0,1,2],3) == [1,0,2]
 
+# Immutable AbstractArrays
+@test nthperm(1:5, 1) == [1,2,3,4,5]
+
 @test_throws ArgumentError parity([0])
 @test_throws ArgumentError parity([1,2,3,3])
 @test levicivita([1,1,2,3]) == 0


### PR DESCRIPTION
Fixes #59. The method signatures for `nthperm` already allow `AbstractArray`, the difference is just that `nthperm!(x, n)` assumes that `x` is mutable and `copy` doesn't always return a mutable collection, e.g. with `UnitRange`s.