### PR TITLE
Give access to non-allocating combinations iterator

### DIFF
--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -5,37 +5,33 @@ export combinations,
        powerset
 
 #The Combinations iterator
-
-struct Combinations{T}
-    a::T
+struct Combinations
+    n::Int
     t::Int
 end
 
-function Base.iterate(c::Combinations, s = collect(1:c.t))
-    (!isempty(s) && s[1] > length(c.a) - c.t + 1) && return
-
-    comb = [c.a[si] for si in s]
-    if c.t == 0
-        # special case to generate 1 result for t==0
-        return (comb, [length(c.a)+2])
+function Base.iterate(c::Combinations, s = [min(c.t - 1, i) for i in 1:c.t])
+    if c.t == 0 # special case to generate 1 result for t==0
+        isempty(s) && return (s, [1])
+        return
     end
-    s = copy(s)
-    for i = length(s):-1:1
+    for i in c.t:-1:1
         s[i] += 1
-        if s[i] > (length(c.a) - (length(s) - i))
+        if s[i] > (c.n - (c.t - i))
             continue
         end
-        for j = i+1:lastindex(s)
-            s[j] = s[j-1]+1
+        for j in i+1:c.t
+            s[j] = s[j-1] + 1
         end
         break
     end
-    (comb, s)
+    s[1] > c.n - c.t + 1 && return
+    (s, s)
 end
 
-Base.length(c::Combinations) = binomial(length(c.a), c.t)
+Base.length(c::Combinations) = binomial(c.n, c.t)
 
-Base.eltype(::Type{Combinations{T}}) where {T} = Vector{eltype(T)}
+Base.eltype(::Type{Combinations}) = Vector{Int}
 
 """
     combinations(a, n)
@@ -49,7 +45,8 @@ function combinations(a, t::Integer)
         # generate 0 combinations for negative argument
         t = length(a) + 1
     end
-    Combinations(a, t)
+    reorder(c) = [a[ci] for ci in c]
+    (reorder(c) for c in Combinations(length(a), t))
 end
 
 

--- a/src/multinomials.jl
+++ b/src/multinomials.jl
@@ -4,7 +4,7 @@
 export multiexponents
 
 struct MultiExponents{T}
-    c::Combinations{T}
+    c::T
     nterms::Int
 end
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -1,10 +1,10 @@
 @test [combinations([])...] == []
-@test [combinations(['a', 'b', 'c'])...] == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
+@test [combinations(['a', 'b', 'c'])...] == [['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
 
-@test [combinations("abc",3)...] == Any[['a','b','c']]
-@test [combinations("abc",2)...] == Any[['a','b'],['a','c'],['b','c']]
-@test [combinations("abc",1)...] == Any[['a'],['b'],['c']]
-@test [combinations("abc",0)...] == Any[[]]
+@test [combinations("abc",3)...] == [['a','b','c']]
+@test [combinations("abc",2)...] == [['a','b'],['a','c'],['b','c']]
+@test [combinations("abc",1)...] == [['a'],['b'],['c']]
+@test [combinations("abc",0)...] == [[]]
 @test [combinations("abc",-1)...] == []
 
 @test filter(x->iseven(x[1]),[combinations([1,2,3],2)...]) == Any[[2,3]]


### PR DESCRIPTION
This gives access to the non-allocating `Combinations` internals such that e.g. a copy of the changing state can be made with `SVector`.


Old:
```
julia> @btime collect(combinations(1:50,5))
  883.211 ms (8475043 allocations: 695.09 MiB)

julia> function f()
           i = 0
           for c in combinations(1:50, 5)
               i = i + c[1]
           end
           i
       end
f (generic function with 1 method)

julia> @btime f()
  1.079 s (8475041 allocations: 678.92 MiB)
18009460
```


New:
```
julia> @btime collect(combinations(1:50,5))
  303.784 ms (6356283 allocations: 404.12 MiB)

julia> @btime f()
  246.004 ms (6356281 allocations: 387.96 MiB)
18009460

julia> function g()
           i = 0
           for c in Combinatorics.Combinations(50, 5)
               i = i + c[1]
           end
           i
       end
g (generic function with 1 method)

julia> @btime g()
  71.276 ms (2118761 allocations: 64.66 MiB)
18009460

julia> @btime map(SVector{5,Int},Combinatorics.Combinations(50,5))
  100.676 ms (2118764 allocations: 145.48 MiB)
```

Actually, I do not see why it should still allocate in each iteration in `g`, maybe you see something or one should sprinkle some `inbounds`.
