### PR TITLE
Bump Polynomials compat to include v0.7, v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ julia:
   - 1.0
   - 1.3
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 codecov: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ julia:
   - 1.0
   - 1.3
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
 notifications:
   email: false
 codecov: true

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 
 [compat]
-Polynomials = "0.5, 0.6, 0.7"
+Polynomials = "0.5, 0.6, 0.7, 0.8"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 
 [compat]
-Polynomials = "0.5, 0.6"
+Polynomials = "0.5, 0.6, 0.7"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Would have expected ~~TagBot~~ CompatHelper to take care of this.

Edit: Not TagBot but CompatHelper should take care of this.  CompatHelper is not activated on this repo.