### PR TITLE
Remove stale dependency on Polynomials.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,11 +2,7 @@ name = "Combinatorics"
 uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 version = "1.0.1"
 
-[deps]
-Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-
 [compat]
-Polynomials = "0.5, 0.6, 0.7, 0.8"
 julia = "1"
 
 [extras]

--- a/src/Combinatorics.jl
+++ b/src/Combinatorics.jl
@@ -1,8 +1,6 @@
 
 module Combinatorics
 
-using Polynomials
-
 include("numbers.jl")
 include("factorials.jl")
 include("combinations.jl")


### PR DESCRIPTION
Apparently Polynomials.jl is not used in this package anymore, so remove the `using`-statement and remove the dependencies.

Right now, unused depedency blocks Polynomials version upgrade to v1.