### PR TITLE
Improve partitions performance

### DIFF
--- a/test/partitions.jl
+++ b/test/partitions.jl
@@ -1,3 +1,5 @@
+@test collect(partitions(-1)) == []
+@test collect(partitions(0)) == [Int[]]
 @test collect(partitions(4)) ==  Any[[4], [3,1], [2,2], [2,1,1], [1,1,1,1]]
 @test collect(partitions(8,3)) == Any[[6,1,1], [5,2,1], [4,3,1], [4,2,2], [3,3,2]]
 @test collect(partitions(8, 1)) == Any[[8]]
@@ -14,6 +16,7 @@
 @inferred first(partitions([1,2,3,4],3))
 
 @test isa(collect(partitions(4)), Vector{Vector{Int}})
+@test isa(collect(partitions(Int8(4))), Vector{Vector{Int8}})
 @test isa(collect(partitions(8,3)), Vector{Vector{Int}})
 @test isa(collect(partitions([1,2,3])), Vector{Vector{Vector{Int}}})
 @test isa(collect(partitions([1,2,3,4], 3)), Vector{Vector{Vector{Int}}})
@@ -26,9 +29,9 @@
 @test length(collect(partitions('a':'h',5))) == length(partitions('a':'h',5))
 
 # integer_partitions
-@test integer_partitions(0) == []
-@test integer_partitions(5) == Any[[1, 1, 1, 1, 1], [2, 1, 1, 1], [2, 2, 1], [3, 1, 1], [3, 2], [4, 1], [5]]
-@test_throws DomainError integer_partitions(-1)
+@test integer_partitions(0, warn=false) == []
+@test integer_partitions(5, warn=false) == Any[[1, 1, 1, 1, 1], [2, 1, 1, 1], [2, 2, 1], [3, 1, 1], [3, 2], [4, 1], [5]]
+@test_throws DomainError integer_partitions(-1, warn=false)
 
 @test_throws ArgumentError prevprod([2,3,5],Int128(typemax(Int))+1)
 @test prevprod([2,3,5],30) == 30


### PR DESCRIPTION
Here are some timings for comparison.
before
```julia
julia> @btime collect(partitions(10));
  3.995 μs (85 allocations: 6.12 KiB)

julia> @btime collect(partitions(30));
  772.853 μs (11210 allocations: 1017.45 KiB)

julia> @btime collect(partitions(50));
  35.195 ms (408454 allocations: 42.44 MiB)
```
after
```julia
julia> @btime collect(partitions(10));
  1.467 μs (44 allocations: 5.53 KiB)

julia> @btime collect(partitions(30));
  222.300 μs (5607 allocations: 930.16 KiB)

julia> @btime collect(partitions(50));
  10.732 ms (204229 allocations: 39.36 MiB)
```
This is about the same speed as `JuLie.partitions` or `AbstractAlgebra.Generic.partitions`. Also the algorithm is fairly simple and straightforward :)

Some other remarks
* Use type parameter so one can use `partitions(Int8(n))` to save some memory for large n (the partitions are generated as `Vector{Int8}` in this case);
* For consistency, `partitions(0)` returns `[Int[]]` and `partitions(-1)` returns an empty iterator (this is treated in #82 but has not been merged);
* Added deprecation warning for `integer_partitions` (which I'd suggest to replace completely with `collect(partitions(n))`).