### PR TITLE
add multicombinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This library provides the following functions:
  - `lassallenum(n)`: returns the nth Lassalle number A<sub>n</sub> defined in [arXiv:1009.4225](http://arxiv.org/abs/1009.4225) ([OEIS A180874](http://oeis.org/A180874)); always returns a `BigInt`;
  - `legendresymbol(a,p)`: returns the Legendre symbol (a/p);
  - `lucasnum(n)`: the n-th Lucas number; always returns a `BigInt`;
+ - `multichoose(n,k)`: number of ways to choose `k` elements from a `n` element set with duplicates but without order;
+ - `multicombinations(a,k)`: returns all combinations of `n` elements of indexable object `a`;;
  - `multifactorial(n)`: returns the m-multifactorial n(!^m); always returns a `BigInt`;
  - `multinomial(k...)`: receives a tuple of `k_1, ..., k_n` and calculates the multinomial coefficient `(n k)`, where `n = sum(k)`; returns a `BigInt` only if given a `BigInt`;
  - `multiexponents(m,n)`: returns the exponents in the multinomial expansion (x₁ + x₂ + ... + xₘ)ⁿ;

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library provides the following functions:
  - `catalannum(n)`: returns the n-th Catalan number; always returns a `BigInt`;
  - `lobbnum(m,n)`: returns the generalised Catalan number at `m` and `n`; always returns a `BigInt`;
  - `narayana(n,k)`: returns the general Narayana number at any given `n` and `k`; always returns a `BigInt`;
- - `combinations(a,n)`: returns all combinations of `n` elements of indexable object `a`;
+ - `combinations(a,k)`: returns all combinations of `k` elements of indexable object `a`;
  - `combinations(a)`: returns combinations of all order by chaining calls to `combinations(a,n)`;
  - `derangement(n)`/`subfactorial(n)`: returns the number of permutations of n with no fixed points; always returns a `BigInt`;
  - `partialderangement(n, k)`: returns the number of permutations of n with exactly k fixed points; always returns a `BigInt`;

--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -36,11 +36,11 @@ Base.length(c::Combinations) = binomial(c.n, c.t)
 Base.eltype(::Type{Combinations}) = Vector{Int}
 
 """
-    combinations(a, n)
+    combinations(a, k)
 
-Generate all combinations of `n` elements from an indexable object `a`. Because the number
+Generate all combinations of `k` elements from an indexable object `a`. Because the number
 of combinations can be very large, this function returns an iterator object.
-Use `collect(combinations(a, n))` to get an array of all combinations.
+Use `collect(combinations(a, k))` to get an array of all combinations.
 """
 function combinations(a, t::Integer)
     if t < 0

--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -2,6 +2,8 @@ export combinations,
        CoolLexCombinations,
        multiset_combinations,
        with_replacement_combinations,
+       multichoose,
+       multicombinations,
        powerset
 
 #The Combinations iterator
@@ -259,6 +261,66 @@ function Base.iterate(c::WithReplacementCombinations, s = [1 for i in 1:c.t])
     end
     (comb, s)
 end
+
+# the number of multicombinations
+
+"""
+    multichoose(n, k)
+
+Computes the number of ways to take `k` elements from a set of `n` elements while allowing
+duplicates but disregarding the ordering. In other words, it calculates the number of
+nonnegative integer solutions to the Dophantine equation `x_1 + … + x_n = k`.
+"""
+function multichoose(n::Integer, k:: Integer) :: Integer
+    binomial(n + k - 1, k)
+end
+
+
+# the Multicombinations iterator
+struct Multicombinations
+    n::Int
+    k::Int
+end
+
+function Base.iterate(c::Multicombinations, s = [min(1, c.k - i) for i in 1:c.k])
+    if c.k < 0 # special case to generate no result for k<0
+        return
+    end
+    if c.k == 0 # special case to generate 1 result for k==0
+        isempty(s) && return (s, [1])
+        return
+    end
+    if s[1] == s[c.k] == c.n # end iteration because there is none left
+        return
+    end
+    for i in c.k:-1:1
+        if s[i] >= c.n
+            continue
+        end
+        s[i] += 1
+        for j in i+1:c.k
+            s[j] = s[i]
+        end
+        break
+    end
+    return (s, s)
+end
+
+Base.length(m::Multicombinations) = multichoose(m.n, m.k)
+
+Base.eltype(::Type{Multicombinations}) = Vector{Int}
+
+"""
+    multicombinations(a, k)
+Generate all multicombinations of `k` elements from an indexable object `a` in lexikographic order.
+Because the number of multicombinations can be very large, this function returns an iterator object.
+Use `collect(multicombinations(a, k))` to get an array of all multicombinations.
+"""
+function multicombinations(a, k::Integer)
+    reorder(c) = [a[ci] for ci in c]
+    (reorder(c) for c in Multicombinations(length(a), k))
+end
+
 
 ## Power set
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -36,6 +36,30 @@
 @test [CoolLexCombinations(4,2)...] == Vector[[1,2], [2,3], [1,3], [2,4], [3,4], [1,4]]
 @test isa(iterate(CoolLexCombinations(1000, 20))[2], Combinatorics.CoolLexIterState{BigInt})
 
+
+# multichoose
+@test multichoose(0, 1) == 0
+@test multichoose(0, 2) == 0
+@test multichoose(0, 3) == 0
+@test multichoose(1, 1) == 1
+@test multichoose(1, 2) == 1
+@test multichoose(1, 3) == 1
+@test multichoose(2, 1) == 2
+@test multichoose(2, 2) == 3
+@test multichoose(2, 3) == 4
+@test multichoose(3, 0) == 1
+@test multichoose(3, 1) == 3
+@test multichoose(3, 2) == 6
+@test multichoose(3, 3) == 10
+@test multichoose(10, 8) == 24310
+
+# multicombinations
+@test [multicombinations("abc", 0)...] == [Char[]]
+@test [multicombinations("abc", 1)...] == [['a'], ['b'], ['c']]
+@test [multicombinations("abc", 2)...] == [['a','a'], ['a','b'], ['a','c'], ['b','b'], ['b','c'], ['c','c']]
+@test [multicombinations("abc", 3)...] == [['a','a','a'], ['a','a','b'], ['a','a','c'], ['a','b','b'],
+    ['a','b','c'], ['a','c','c'], ['b','b','b'], ['b','b','c'], ['b','c','c'], ['c','c','c']]
+    
 # Power set
 @test collect(powerset([])) == Any[[]]
 @test collect(powerset(['a', 'b', 'c'])) == Any[[],['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]


### PR DESCRIPTION
I have added support for multicombinations (see [Wikipedia](https://en.wikipedia.org/wiki/Combination#Number_of_combinations_with_repetition)) and the number of them.
The implementation is very close to the existing one for combinations.

I furthermore slightly changed the combinations' documentation to let `n` denote the cardinality of the set choosing from and `k` the number of elements to take.