### PR TITLE
Add tests based on python's itertools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ julia = "1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 
 [targets]
-test = ["LinearAlgebra", "OffsetArrays", "Test"]
+test = ["LinearAlgebra", "OffsetArrays", "Test", "PyCall"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -39,9 +39,9 @@
 
     # Power set
     @test collect(powerset([])) == Any[[]]
-    @test collect(powerset(['a', 'b', 'c'])) == Any[[],['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
-    @test collect(powerset(['a', 'b', 'c'], 1)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
-    @test collect(powerset(['a', 'b', 'c'], 1, 2)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c']]
+    @test collect(powerset(['a', 'b', 'c'])) == Any[[], ['a'], ['b'], ['c'], ['a', 'b'], ['a', 'c'], ['b', 'c'], ['a', 'b', 'c']]
+    @test collect(powerset(['a', 'b', 'c'], 1)) == Any[['a'], ['b'], ['c'], ['a', 'b'], ['a', 'c'], ['b', 'c'], ['a', 'b', 'c']]
+    @test collect(powerset(['a', 'b', 'c'], 1, 2)) == Any[['a'], ['b'], ['c'], ['a', 'b'], ['a', 'c'], ['b', 'c']]
 
     @testset "combinations prop test n=10, k=5" begin
         n = 1:10

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -41,3 +41,40 @@
 @test collect(powerset(['a', 'b', 'c'])) == Any[[],['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
 @test collect(powerset(['a', 'b', 'c'], 1)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
 @test collect(powerset(['a', 'b', 'c'], 1, 2)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c']]
+
+@testset "combinations fuzzing n=10, k=5" begin
+    n = 1:10
+    k = 5
+    for (jl, py) in zip(
+        combinations(n, k),
+        pyitertools.combinations(n, k),
+    )
+        @test jl == collect(py)
+    end
+end
+
+@testset "combinations fuzzing n=100, k=2" begin
+    n = 1:100
+    k = 2
+    for (jl, py) in zip(
+        combinations(n, k),
+        pyitertools.combinations(n, k),
+    )
+        @test jl == collect(py)
+    end
+end
+
+@testset "string combinations fuzzing n=20, k=3" begin
+    function pairwise(x)
+        zip(x, Iterators.drop(x, 1))
+    end
+    s = "abcdefghijklmnopqrstu"
+    s2 = pairwise(s)
+    k = 3
+    for (jl, py) in zip(
+        combinations(s2, k),
+        pyitertools.combinations(s2, k),
+    )
+        @test jl == collect(py)
+    end
+end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -37,82 +37,76 @@
     @test [CoolLexCombinations(4, 2)...] == Vector[[1, 2], [2, 3], [1, 3], [2, 4], [3, 4], [1, 4]]
     @test isa(iterate(CoolLexCombinations(1000, 20))[2], Combinatorics.CoolLexIterState{BigInt})
 
-# Power set
-@test collect(powerset([])) == Any[[]]
-@test collect(powerset(['a', 'b', 'c'])) == Any[[],['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
-@test collect(powerset(['a', 'b', 'c'], 1)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
-@test collect(powerset(['a', 'b', 'c'], 1, 2)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c']]
+    # Power set
+    @test collect(powerset([])) == Any[[]]
+    @test collect(powerset(['a', 'b', 'c'])) == Any[[],['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
+    @test collect(powerset(['a', 'b', 'c'], 1)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
+    @test collect(powerset(['a', 'b', 'c'], 1, 2)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c']]
 
-@testset "combinations fuzzing n=10, k=5" begin
-    n = 1:10
-    k = 5
-    for (jl, py) in zip(
-        combinations(n, k),
-        pyitertools.combinations(n, k),
-    )
-        @test jl == collect(py)
+    @testset "combinations fuzzing n=10, k=5" begin
+        n = 1:10
+        k = 5
+        for (jl, py) in zip(
+            combinations(n, k),
+            pyitertools.combinations(n, k),
+        )
+            @test jl == collect(py)
+        end
     end
-end
 
-@testset "combinations fuzzing n=100, k=2" begin
-    n = 1:100
-    k = 2
-    for (jl, py) in zip(
-        combinations(n, k),
-        pyitertools.combinations(n, k),
-    )
-        @test jl == collect(py)
+    @testset "combinations fuzzing n=100, k=2" begin
+        n = 1:100
+        k = 2
+        for (jl, py) in zip(
+            combinations(n, k),
+            pyitertools.combinations(n, k),
+        )
+            @test jl == collect(py)
+        end
     end
-end
 
-@testset "string combinations fuzzing n=20, k=3" begin
-    function pairwise(x)
-        zip(x, Iterators.drop(x, 1))
+    @testset "string combinations fuzzing n=20, k=3" begin
+        s = collect("abcdefghijklmnopqrstu")
+        k = 3
+        for (jl, py) in zip(
+            combinations(s, k),
+            pyitertools.combinations(s, k),
+        )
+            @test jl == collect(py)
+        end
     end
-    s = "abcdefghijklmnopqrstu"
-    s2 = collect(pairwise(s))
-    k = 3
-    for (jl, py) in zip(
-        combinations(s2, k),
-        pyitertools.combinations(s2, k),
-    )
-        @test jl == collect(py)
-    end
-end
 
-@testset "with_replacement_combinations fuzzing n=10, k=5" begin
-    n = 1:10
-    k = 5
-    for (jl, py) in zip(
-        with_replacement_combinations(n, k),
-        pyitertools.combinations_with_replacement(n, k),
-    )
-        @test jl == collect(py)
+    @testset "with_replacement_combinations fuzzing n=10, k=5" begin
+        n = 1:10
+        k = 5
+        for (jl, py) in zip(
+            with_replacement_combinations(n, k),
+            pyitertools.combinations_with_replacement(n, k),
+        )
+            @test jl == collect(py)
+        end
     end
-end
 
-@testset "with_replacement_combinations fuzzing n=100, k=2" begin
-    n = 1:100
-    k = 2
-    for (jl, py) in zip(
-        with_replacement_combinations(n, k),
-        pyitertools.combinations_with_replacement(n, k),
-    )
-        @test jl == collect(py)
+    @testset "with_replacement_combinations fuzzing n=100, k=2" begin
+        n = 1:100
+        k = 2
+        for (jl, py) in zip(
+            with_replacement_combinations(n, k),
+            pyitertools.combinations_with_replacement(n, k),
+        )
+            @test jl == collect(py)
+        end
     end
-end
 
-@testset "string with_replacement_combinations fuzzing n=20, k=3" begin
-    function pairwise(x)
-        zip(x, Iterators.drop(x, 1))
+    @testset "string with_replacement_combinations fuzzing n=20, k=3" begin
+        s = collect("abcdefghijklmnopqrstu")
+        k = 3
+        for (jl, py) in zip(
+            with_replacement_combinations(s, k),
+            pyitertools.combinations_with_replacement(s, k),
+        )
+            @test jl == collect(py)
+        end
     end
-    s = "abcdefghijklmnopqrstu"
-    s2 = collect(pairwise(s))
-    k = 3
-    for (jl, py) in zip(
-        with_replacement_combinations(s2, k),
-        pyitertools.combinations_with_replacement(s2, k),
-    )
-        @test jl == collect(py)
-    end
+
 end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -69,11 +69,48 @@ end
         zip(x, Iterators.drop(x, 1))
     end
     s = "abcdefghijklmnopqrstu"
-    s2 = pairwise(s)
+    s2 = collect(pairwise(s))
     k = 3
     for (jl, py) in zip(
         combinations(s2, k),
         pyitertools.combinations(s2, k),
+    )
+        @test jl == collect(py)
+    end
+end
+
+@testset "with_replacement_combinations fuzzing n=10, k=5" begin
+    n = 1:10
+    k = 5
+    for (jl, py) in zip(
+        with_replacement_combinations(n, k),
+        pyitertools.combinations_with_replacement(n, k),
+    )
+        @test jl == collect(py)
+    end
+end
+
+@testset "with_replacement_combinations fuzzing n=100, k=2" begin
+    n = 1:100
+    k = 2
+    for (jl, py) in zip(
+        with_replacement_combinations(n, k),
+        pyitertools.combinations_with_replacement(n, k),
+    )
+        @test jl == collect(py)
+    end
+end
+
+@testset "string with_replacement_combinations fuzzing n=20, k=3" begin
+    function pairwise(x)
+        zip(x, Iterators.drop(x, 1))
+    end
+    s = "abcdefghijklmnopqrstu"
+    s2 = collect(pairwise(s))
+    k = 3
+    for (jl, py) in zip(
+        with_replacement_combinations(s2, k),
+        pyitertools.combinations_with_replacement(s2, k),
     )
         @test jl == collect(py)
     end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -43,7 +43,7 @@
     @test collect(powerset(['a', 'b', 'c'], 1)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
     @test collect(powerset(['a', 'b', 'c'], 1, 2)) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c']]
 
-    @testset "combinations fuzzing n=10, k=5" begin
+    @testset "combinations prop test n=10, k=5" begin
         n = 1:10
         k = 5
         for (jl, py) in zip(
@@ -54,7 +54,7 @@
         end
     end
 
-    @testset "combinations fuzzing n=100, k=2" begin
+    @testset "combinations prop test n=100, k=2" begin
         n = 1:100
         k = 2
         for (jl, py) in zip(
@@ -65,7 +65,7 @@
         end
     end
 
-    @testset "string combinations fuzzing n=20, k=3" begin
+    @testset "string combinations prop test n=20, k=3" begin
         s = collect("abcdefghijklmnopqrstu")
         k = 3
         for (jl, py) in zip(
@@ -76,7 +76,7 @@
         end
     end
 
-    @testset "with_replacement_combinations fuzzing n=10, k=5" begin
+    @testset "with_replacement_combinations prop test n=10, k=5" begin
         n = 1:10
         k = 5
         for (jl, py) in zip(
@@ -87,7 +87,7 @@
         end
     end
 
-    @testset "with_replacement_combinations fuzzing n=100, k=2" begin
+    @testset "with_replacement_combinations prop test n=100, k=2" begin
         n = 1:100
         k = 2
         for (jl, py) in zip(
@@ -98,7 +98,7 @@
         end
     end
 
-    @testset "string with_replacement_combinations fuzzing n=20, k=3" begin
+    @testset "string with_replacement_combinations prop test n=20, k=3" begin
         s = collect("abcdefghijklmnopqrstu")
         k = 3
         for (jl, py) in zip(

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -30,7 +30,7 @@ end
     @test collect(permutations([], -1)) == Any[]
     @test collect(permutations([], 0)) == [Any[]]
     @test collect(permutations([], 1)) == Any[]
-    
+
     @testset "permutation lengths" begin
         expected_lengths = [1, 5, 20, 60, 120, 120]
         ks = 0:5
@@ -104,5 +104,38 @@ end
 
     @test Combinatorics.nsetpartitions(-1) == 0
     @test collect(permutations([])) == [[]]
+
+    @testset "permutations prop test n=10, k=5" begin
+        n = 1:10
+        k = 5
+        for (jl, py) in zip(
+            permutations(n, k),
+            pyitertools.permutations(n, k),
+        )
+            @test jl == collect(py)
+        end
+    end
+
+    @testset "permutations prop test n=100, k=2" begin
+        n = 1:100
+        k = 2
+        for (jl, py) in zip(
+            permutations(n, k),
+            pyitertools.permutations(n, k),
+        )
+            @test jl == collect(py)
+        end
+    end
+
+    @testset "string permutations prop test n=20, k=3" begin
+        s = collect("abcdefghijklmnopqrstu")
+        k = 3
+        for (jl, py) in zip(
+            permutations(s, k),
+            pyitertools.permutations(s, k),
+        )
+            @test jl == collect(py)
+        end
+    end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Combinatorics
 using Test
+using PyCall: pyimport
+pyitertools = pyimport("itertools")
 
 include("numbers.jl")
 include("factorials.jl")


### PR DESCRIPTION
Feel free to ignore and close this PR without explanation.

The basic idea here is to test the Julia version against the [python itertools](https://docs.python.org/3/library/itertools.html).

Assumptions: python's `itertools` library is correct.  

- Benefits:  
    - Can verify behavior for longer sequences. This could help find corner cases not explored in the current, smaller test set.  
    - Greatly expands the test set with only a little code added to the repo.  
- Downsides:  
    - If the algorithms are ever changed in such a way that the order of combinations/permutations produced changes, these tests will be useless, and will have to be removed.  
    - Have to add PyCall as a test dependency. Could make CI take longer to run.