### PR TITLE
Make `multiexponents` type stable

### DIFF
--- a/src/multinomials.jl
+++ b/src/multinomials.jl
@@ -26,6 +26,7 @@ function Base.iterate(m::MultiExponents, s = nothing)
 end
 
 Base.length(m::MultiExponents) = length(m.c)
+Base.eltype(::Type{MultiExponents{T}}) where {T} = Vector{Int}
 
 """
     multiexponents(m, n)
@@ -35,15 +36,16 @@ Returns the exponents in the multinomial expansion (x₁ + x₂ + ... + xₘ)ⁿ
 For example, the expansion (x₁ + x₂ + x₃)² = x₁² + x₁x₂ + x₁x₃ + ...
 has the exponents:
 
-    julia> collect(multiexponents(3, 2))
-
-    6-element Array{Any,1}:
-     [2, 0, 0]
-     [1, 1, 0]
-     [1, 0, 1]
-     [0, 2, 0]
-     [0, 1, 1]
-     [0, 0, 2]
+```julia-repl
+julia> collect(multiexponents(3, 2))
+6-element Vector{Vector{Int64}}:
+ [2, 0, 0]
+ [1, 1, 0]
+ [1, 0, 1]
+ [0, 2, 0]
+ [0, 1, 1]
+ [0, 0, 2]
+```
 """
 function multiexponents(m, n)
     # number of stars and bars = m+n-1

--- a/test/multinomials.jl
+++ b/test/multinomials.jl
@@ -25,4 +25,7 @@ using LinearAlgebra
     @test [multiexponents(2, 2)...] == [[2, 0], [1, 1], [0, 2]]
     @test [multiexponents(3, 3)...] == [[3, 0, 0], [2, 1, 0], [2, 0, 1], [1, 2, 0], [1, 1, 1], [1, 0, 2], [0, 3, 0], [0, 2, 1], [0, 1, 2], [0, 0, 3]]
 
+    # type-stability
+    @test typeof([multiexponents(1, 1)...]) == typeof([[1]])
+    @test eltype(multiexponents(1, 1)) == eltype([[1]])
 end

--- a/test/multinomials.jl
+++ b/test/multinomials.jl
@@ -25,6 +25,9 @@ using LinearAlgebra
     @test [multiexponents(2, 2)...] == [[2, 0], [1, 1], [0, 2]]
     @test [multiexponents(3, 3)...] == [[3, 0, 0], [2, 1, 0], [2, 0, 1], [1, 2, 0], [1, 1, 1], [1, 0, 2], [0, 3, 0], [0, 2, 1], [0, 1, 2], [0, 0, 3]]
 
+    @test length(multiexponents(1, 1)) == 1
+    @test length(multiexponents(2, 2)) == 3
+
     # type-stability
     @test typeof([multiexponents(1, 1)...]) == Vector{Vector{Int}}
     @test eltype(multiexponents(1, 1)) == Vector{Int}

--- a/test/multinomials.jl
+++ b/test/multinomials.jl
@@ -26,6 +26,6 @@ using LinearAlgebra
     @test [multiexponents(3, 3)...] == [[3, 0, 0], [2, 1, 0], [2, 0, 1], [1, 2, 0], [1, 1, 1], [1, 0, 2], [0, 3, 0], [0, 2, 1], [0, 1, 2], [0, 0, 3]]
 
     # type-stability
-    @test typeof([multiexponents(1, 1)...]) == typeof([[1]])
-    @test eltype(multiexponents(1, 1)) == eltype([[1]])
+    @test typeof([multiexponents(1, 1)...]) == Vector{Vector{Int}}
+    @test eltype(multiexponents(1, 1)) == Vector{Int}
 end


### PR DESCRIPTION
`collect` called on `MultiExponents` is type-unstable because `MultiExponents` has no defined `eltype`. This PR adds a method for `Base.eltype()` so that `collect` returns a `Vector{Vector{Int64}}` rather than a `Vector{Any}`.

Before:

```julia-repl
julia> collect(multiexponents(3, 2))
6-element Array{Any,1}:
 [2, 0, 0]
 [1, 1, 0]
 [1, 0, 1]
 [0, 2, 0]
 [0, 1, 1]
 [0, 0, 2]
```

After:

```julia-repl
julia> collect(multiexponents(3, 2))
6-element Vector{Vector{Int64}}:
 [2, 0, 0]
 [1, 1, 0]
 [1, 0, 1]
 [0, 2, 0]
 [0, 1, 1]
 [0, 0, 2]
```