### PR TITLE
Improve performance of `derangement`/`subfactorial` with iterative implementation

### DIFF
--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -44,11 +44,17 @@ function derangement(n::Integer)
     elseif n <= 1
         return BigInt(1-n)
     end
-    a, b = BigInt(1), BigInt(0)
+    d = BigInt(0)
     for i in 2:n
-        a, b = b, (i-1)*(a+b)
+        # d = i * d + (iseven(i) ? 1 : -1)
+        Base.GMP.MPZ.mul_ui!(d, i)
+        if iseven(i)
+            Base.GMP.MPZ.add_ui!(d, 1)
+        else
+            Base.GMP.MPZ.sub_ui!(d, 1)
+        end
     end
-    return b
+    return d
 end
 const subfactorial = derangement
 

--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -38,9 +38,17 @@ Base.factorial(n::Integer, k::Integer) = factorial(promote(n, k)...)
 Compute the number of permutations of `n` with no fixed points, also known as the
 subfactorial. An alias `subfactorial` for this function is provided for convenience.
 """
-function derangement(sn::Integer)
-    n = BigInt(sn)
-    return numerator(factorial(n) * sum([(-1)^k // factorial(k) for k = 0:n]))
+function derangement(n::Integer)
+    if n < 0
+        throw(DomainError(n, "n must be nonnegative"))
+    elseif n <= 1
+        return BigInt(1-n)
+    end
+    a, b = BigInt(1), BigInt(0)
+    for i in 2:n
+        a, b = b, (i-1)*(a+b)
+    end
+    return b
 end
 const subfactorial = derangement
 

--- a/test/factorials.jl
+++ b/test/factorials.jl
@@ -11,6 +11,7 @@
     # derangement
     @test derangement(4) == subfactorial(4) == 9
     @test derangement(24) == parse(BigInt, "228250211305338670494289")
+    @test_throws DomainError derangement(-1)
 
     # partialderangement
     @test partialderangement(7, 3) == 315

--- a/test/factorials.jl
+++ b/test/factorials.jl
@@ -10,6 +10,8 @@
 
     # derangement
     @test derangement(4) == subfactorial(4) == 9
+    @test derangement(0) == 1
+    @test derangement(1) == 0
     @test derangement(24) == parse(BigInt, "228250211305338670494289")
     @test_throws DomainError derangement(-1)
 


### PR DESCRIPTION
This PR changes the implementation of `derangement`, hence also `subfactorial`,
to use the recursive formula `!n = (n-1) * (!(n-1) + !(n-2))` presented [here](https://en.wikipedia.org/wiki/Derangement#Counting_derangements).

For values such as `subfactorial(100)` I get a huge speed-up, like ~10x.