### PR TITLE
inline iterate method to avoid allocations 

### DIFF
--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -10,7 +10,7 @@ struct Combinations
     t::Int
 end
 
-function Base.iterate(c::Combinations, s = [min(c.t - 1, i) for i in 1:c.t])
+@inline function Base.iterate(c::Combinations, s = [min(c.t - 1, i) for i in 1:c.t])
     if c.t == 0 # special case to generate 1 result for t==0
         isempty(s) && return (s, [1])
         return


### PR DESCRIPTION
Use `@inline` on iterate method of Combinations to avoid allocations when creating return tuple

Closes #147 
