### PR TITLE
Improve `factorial(n, k)` performance for `BigInt`

### DIFF
--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -29,6 +29,17 @@ function Base.factorial(n::T, k::T) where T<:Integer
     end
     return f
 end
+function Base.factorial(n::BigInt, k::BigInt)
+    if k < 0 || n < 0 || k > n
+        throw(DomainError((n, k), "n and k must be nonnegative with k ≤ n"))
+    end
+    f = BigInt(1)
+    while n > k
+        Base.GMP.MPZ.mul!(f, n)
+        Base.GMP.MPZ.sub_ui!(n, 1)
+    end
+    return f
+end
 Base.factorial(n::Integer, k::Integer) = factorial(promote(n, k)...)
 
 

--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -34,6 +34,7 @@ function Base.factorial(n::BigInt, k::BigInt)
         throw(DomainError((n, k), "n and k must be nonnegative with k ≤ n"))
     end
     f = BigInt(1)
+    n = deepcopy(n)  # avoid mutating input
     while n > k
         Base.GMP.MPZ.mul!(f, n)
         Base.GMP.MPZ.sub_ui!(n, 1)

--- a/test/factorials.jl
+++ b/test/factorials.jl
@@ -3,6 +3,9 @@
     @test_throws DomainError factorial(3, 7)
     @test_throws DomainError factorial(-3, -7)
     @test_throws DomainError factorial(-7, -3)
+    @test_throws DomainError factorial(big"3", big"7")
+    @test_throws DomainError factorial(big"-3", big"7")
+    @test_throws DomainError factorial(big"3", big"-7")
     #JuliaLang/julia#9943
     @test factorial(big(100), (80)) == 1303995018204712451095685346159820800000
     #JuliaLang/julia#9950


### PR DESCRIPTION
Use in-place operations from `Base.GMP.MPZ` to reduce allocations.

With this change I get a *massive speed-up*, for instance I pass from

```text
julia> @benchmark factorial(big"1000", big"500")
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  100.233 μs … 105.019 ms  ┊ GC (min … max):  0.00% … 80.08%
 Time  (median):     116.240 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   259.614 μs ±   2.368 ms  ┊ GC (mean ± σ):  20.95% ±  2.33%

  █▇▇▄▂▁                                                        ▂
  ███████▇▇▇█▅▅▃▃▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄ █
  100 μs        Histogram: log(frequency) by time        962 μs <

 Memory estimate: 192.52 KiB, allocs estimate: 3002.
```

to

```text
julia> @benchmark factorial(big"1000", big"500")
BenchmarkTools.Trial: 10000 samples with 991 evaluations.
 Range (min … max):   49.491 ns … 92.862 μs  ┊ GC (min … max):  0.00% … 52.86%
 Time  (median):      54.742 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   110.839 ns ±  2.088 μs  ┊ GC (mean ± σ):  23.97% ±  1.28%

   ▇█▆▁
  ▂█████▆▆▅▃▂▂▃▅▇▆▄▄▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  49.5 ns         Histogram: frequency by time          105 ns <

 Memory estimate: 40 bytes, allocs estimate: 2.
```

for an approximate 2000x performance boost.