### PR TITLE
Make `multinomial` work for iterable input

### DIFF
--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -93,16 +93,18 @@ function primorial(n::Integer)
 end
 
 """
-    multinomial(k...)
+    multinomial(k)
+    multinomial(k::Integer...)
 
-Multinomial coefficient where `n = sum(k)`.
+Multinomial coefficient ```(n, (k[1], k[2], … ))``` with `n = sum(k)`.
 """
-function multinomial(k...)
-    s = 0
-    result = 1
+function multinomial(k)
+    s = zero(eltype(k))
+    result = one(eltype(k))
     @inbounds for i in k
         s += i
         result *= binomial(s, i)
     end
     result
 end
+multinomial(k::T...) where T<:Integer = multinomial(k)

--- a/test/factorials.jl
+++ b/test/factorials.jl
@@ -33,6 +33,8 @@
 
     # multinomial
     @test multinomial(1, 4, 4, 2) == 34650
+    @test multinomial([1, 4, 4, 2]) == multinomial(1, 4, 4, 2)
+    @test @inferred multinomial(big"1", big"4") isa BigInt
 
     # primorial
     @test primorial(17) == 510510

--- a/test/factorials.jl
+++ b/test/factorials.jl
@@ -34,7 +34,7 @@
     # multinomial
     @test multinomial(1, 4, 4, 2) == 34650
     @test multinomial([1, 4, 4, 2]) == multinomial(1, 4, 4, 2)
-    @test @inferred multinomial(big"1", big"4") isa BigInt
+    @test (@inferred multinomial(big"1", big"4")) isa BigInt
 
     # primorial
     @test primorial(17) == 510510


### PR DESCRIPTION
There's no need to restrict the signature to multi-argument inputs; iterable inputs are arguably more natural. This way, we can avoid splatting if the input is an iterable.