### PR TITLE
Check overflow in multinomial

### DIFF
--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -103,7 +103,7 @@ function multinomial(k...)
     @inbounds for i in k
         s += i
         bi = binomial(s, i)
-        result = Base.checked_mul(result, bi)
+        result = Base.Checked.checked_mul(result, bi)
     end
     result
 end

--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -95,7 +95,34 @@ end
 """
     multinomial(k...)
 
-Multinomial coefficient where `n = sum(k)`.
+Compute the multinomial coefficient
+``\\binom{n}{k_1,k_2,...,k_i} = \\frac{n!}{k_1!k_2! \\cdots k_i!}, n = \\sum{k_i}``.
+Throws an `OverflowError` when the input is too large.
+
+See Also: `binomial`.
+
+# Examples
+```jldoctest
+julia> # (x+y)^2 = x^2 + 2xy + y^2
+
+julia> multinomial(2, 0)
+1
+
+julia> multinomial(1, 1)
+2
+
+julia> multinomial(0, 2)
+1
+
+julia> multinomial(10, 10, 10, 10)
+ERROR: OverflowError: 5550996791340 * 847660528 overflowed for type Int64
+Stacktrace:
+[...]
+```
+
+# External links
+- [Definitions](https://dlmf.nist.gov/26.4.2) on DLMF
+- [Multinomial theorem](https://en.wikipedia.org/wiki/Multinomial_theorem) on Wikipedia
 """
 function multinomial(k...)
     s = 0

--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -102,7 +102,8 @@ function multinomial(k...)
     result = 1
     @inbounds for i in k
         s += i
-        result *= binomial(s, i)
+        bi = binomial(s, i)
+        result = Base.checked_mul(result, bi)
     end
     result
 end

--- a/test/factorials.jl
+++ b/test/factorials.jl
@@ -31,8 +31,17 @@
     @test multifactorial(40, 2) == doublefactorial(40)
     @test_throws DomainError multifactorial(-1, 1)
 
-    # multinomial
-    @test multinomial(1, 4, 4, 2) == 34650
+    @testset "multinomial" begin
+        @test multinomial(1, 4, 4, 2) == 34650
+        # wolfram:  Multinomial[10, 10, 10, 5]
+        @test multinomial(10, 10, 10, 5) == 1_802_031_190_366_286_880
+
+        # checked_mul overflowed for type Int64
+        @test_throws OverflowError multinomial(10, 10, 10, 6)
+        @test_throws OverflowError multinomial(10, 10, 10, 10)
+        # binomial(200, 100) overflows
+        @test_throws OverflowError multinomial(100, 100)  
+    end
 
     # primorial
     @test primorial(17) == 510510

--- a/test/factorials.jl
+++ b/test/factorials.jl
@@ -32,6 +32,11 @@
     @test_throws DomainError multifactorial(-1, 1)
 
     @testset "multinomial" begin
+        # > For k=0,1, the multinomial coefficient is defined to be 1
+        # https://dlmf.nist.gov/26.4#i.p1
+        @test multinomial() == 1
+        @test multinomial(0) == 1
+
         @test multinomial(1, 4, 4, 2) == 34650
         # wolfram:  Multinomial[10, 10, 10, 5]
         @test multinomial(10, 10, 10, 5) == 1_802_031_190_366_286_880


### PR DESCRIPTION
Fix #99

- Check overflow in multinomial. For large input, it will throw a `OverflowError`
- Add new tests for large input and special case.
- Update docs (Maybe it should be split into another pr)

```jl
julia> using Combinatorics

julia> using BenchmarkTools

julia> @benchmark multinomial(10,10,10,5) evals=2000
BenchmarkTools.Trial: 10000 samples with 2000 evaluations.
 Range (min … max):  170.350 ns … 514.200 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     178.400 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   182.391 ns ±  17.635 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆▅▄▃▆█▇▅▄▄▄▃▃▂▁▁▁▁                                            ▂
  ███████████████████▇█▇▇▇▆▇▆▅▇▆▇▅▆▅▆▅▆▆▅▄▅▅▄▆▅▆▅▅▅▅▆▆▅▅▆▅▄▄▅▄▃ █
  170 ns        Histogram: log(frequency) by time        263 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark multinomial_pr(10,10,10,5) evals=2000
BenchmarkTools.Trial: 10000 samples with 2000 evaluations.
 Range (min … max):  170.500 ns … 557.450 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     178.500 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   183.319 ns ±  21.158 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▇▅▇█▇▆▅▅▄▄▃▂▂▂▁▁▁▁                                           ▂
  ████████████████████▇▇█▇█▆▆█▇▇▇▆▆▇▆▆▇▇▆▇▇▆▅▆▇▇▇▆▆▅▆▇▆▅▆▆▅▄▃▄▄ █
  170 ns        Histogram: log(frequency) by time        273 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

