### PR TITLE
Remove undef symbol `gamma`

### DIFF
--- a/src/factorials.jl
+++ b/src/factorials.jl
@@ -8,7 +8,6 @@ export
     doublefactorial,
     hyperfactorial,
     multifactorial,
-    gamma,
     primorial,
     multinomial
 


### PR DESCRIPTION
Fix #168

symbol `gamma` was introduced in 2e5614978c7b751c66a4a2d947344eb1ebf11db6

I think this is a mistake.
