### PR TITLE
Bugfix: let `integer_partitions(0) == [Int[]]`

### DIFF
--- a/src/partitions.jl
+++ b/src/partitions.jl
@@ -646,7 +646,7 @@ function integer_partitions(n::Integer)
     if n < 0
         throw(DomainError(n, "n must be nonnegative"))
     elseif n == 0
-        return Vector{Int}[]
+        return Vector{Int}[[]]
     elseif n == 1
         return Vector{Int}[[1]]
     end

--- a/test/partitions.jl
+++ b/test/partitions.jl
@@ -96,7 +96,7 @@
     end
 
     @testset "integer partitions" begin
-        @test_broken integer_partitions(0) == [[]]
+        @test integer_partitions(0) == [Int[]]
         @test integer_partitions(1) == [[1]]
         @test integer_partitions(2) == [[1, 1], [2]]
         @test integer_partitions(3) == [[1, 1, 1], [2, 1], [3]]

--- a/test/partitions.jl
+++ b/test/partitions.jl
@@ -113,6 +113,16 @@
         # integer_partitions <--> partitions(::Integer)
         @test Set(integer_partitions(5)) == Set(partitions(5))
 
+        # Partition function p(n):  https://oeis.org/A000041
+        @test length(integer_partitions(0)) == 1
+        @test length(integer_partitions(1)) == 1
+        @test length(integer_partitions(2)) == 2
+        @test length(integer_partitions(3)) == 3
+        @test length(integer_partitions(4)) == 5
+        @test length(integer_partitions(5)) == 7
+        @test length(integer_partitions(40)) == 37338
+        @test length(integer_partitions(49)) == 173525
+
         @test_throws DomainError integer_partitions(-1)
     end
 


### PR DESCRIPTION
Fix #138, and half of #143


GAP result:
NOTE: we use the same order as GPA do.
```
GAP 4.11.1 of 2021-03-02

gap> Partitions( 0 );
[ [  ] ]
gap> Partitions( 1 );
[ [ 1 ] ]
gap> Partitions( 2 );
[ [ 1, 1 ], [ 2 ] ]
gap> Partitions( 5 );
[ [ 1, 1, 1, 1, 1 ], [ 2, 1, 1, 1 ], [ 2, 2, 1 ], [ 3, 1, 1 ], [ 3, 2 ], [ 4, 1 ], [ 5 ] ]
```

Wolfram:
```
In[2]:= IntegerPartitions[0]
Out[2]= {{}}
In[4]:= IntegerPartitions[1]
Out[4]= {{1}}
In[5]:= IntegerPartitions[2]
Out[5]= {{2},{1,1}}
In[6]:= IntegerPartitions[5]
Out[6]= {{5},{4,1},{3,2},{3,1,1},{2,2,1},{2,1,1,1},{1,1,1,1,1}}
```
