### PR TITLE
doc: fix typo in `levicivita` doc

### DIFF
--- a/src/permutations.jl
+++ b/src/permutations.jl
@@ -425,7 +425,7 @@ julia> levicivita(collect(1:100))
 
 julia> levicivita(ones(Int, 100))
 0
-````
+```
 """
 function levicivita(p::AbstractVector{<:Integer})
     n = length(p)


### PR DESCRIPTION
Broken doctest: https://juliamath.github.io/Combinatorics.jl/dev/api/#Combinatorics.levicivita-Tuple{AbstractVector{%3C:Integer}}

![image](https://github.com/user-attachments/assets/047d5fb6-828b-4ad5-898d-b2821a3baa94)
