### PR TITLE
Allow calling `stirlings1` and `stirlings2` with `Integer` arguments

### DIFF
--- a/src/numbers.jl
+++ b/src/numbers.jl
@@ -125,7 +125,12 @@ function lucasnum(n::Integer)
     return z[]
 end
 
-function stirlings1(n::Int, k::Int, signed::Bool=false)
+"""
+    stirlings1(n::Integer, k::Integer)
+
+Compute the Stirling number of the first kind, `s(n,k)`.
+"""
+function stirlings1(n::Integer, k::Integer, signed::Bool=false)
     if signed == true
         return (-1)^(n - k) * stirlings1(n, k)
     end
@@ -152,11 +157,11 @@ function stirlings1(n::Int, k::Int, signed::Bool=false)
 end
 
 """
-    stirlings2(n::Int, k::Int)
+    stirlings2(n::Integer, k::Integer)
 
 Compute the Stirling number of the second kind, `S(n,k)`.
 """
-function stirlings2(n::Int, k::Int)
+function stirlings2(n::Integer, k::Integer)
     if n < 0
         throw(DomainError(n, "n must be nonnegative"))
     elseif n == k == 0

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -51,6 +51,7 @@
       @test stirlings1(6, 6) == 1
       @test stirlings1(6, 6, true) == 1
       @test sum([abs(stirlings1(8, i, true)) for i = 0:8]) == factorial(8)
+      @test stirlings1(big"26", 10) == 196928100451110820242880
 
       # stirlings2
       @test_throws DomainError stirlings2(-1, 1)
@@ -65,6 +66,7 @@
       @test stirlings2(6, 4) == 65
       @test stirlings2(6, 5) == 15
       @test stirlings2(6, 6) == 1
+      @test stirlings2(big"26", 10) == 13199555372846848005
 
       # bell
       @test bellnum.(0:10) == [


### PR DESCRIPTION
This allows to call them with `BigInt` arguments to avoid overflow.

Closes #104.