### PR TITLE
ci: use `macos-15-intel`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,8 +7,7 @@ on:
       - master
       - main
     tags: ['*']
-    pull_request:
-    workflow_dispatch:
+  workflow_dispatch:
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
           - os: macos-latest
             version: '1.0'
         include:
-          - os: macos-13  # Intel
+          - os: macos-15-intel  # Intel
             version: '1.0'
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
> The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046