### PR TITLE
Combinatorics performance update

### DIFF
--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -5,48 +5,59 @@ export combinations,
        powerset
 
 #The Combinations iterator
-struct Combinations
-    n::Int
+struct Combinations{T}
+    data::T
     t::Int
 end
 
-@inline function Base.iterate(c::Combinations, s = [min(c.t - 1, i) for i in 1:c.t])
+function Base.iterate(c::Combinations)
+    state = [min(c.t - 1, i) for i in 1:c.t]
     if c.t == 0 # special case to generate 1 result for t==0
-        isempty(s) && return (s, [1])
+        isempty(state) && return (c.data[state], [1])
         return
     end
+    nextcombination!(c, state)
+end
+
+@inline Base.iterate(c::Combinations, state) = nextcombination!(c, state)
+
+Base.length(c::Combinations) = binomial(length(c.data), c.t)
+
+Base.eltype(::Type{Combinations{T}}) where T = Vector{eltype(T)}
+
+@inline function nextcombination!(c::Combinations, idxvec)
     for i in c.t:-1:1
-        s[i] += 1
-        if s[i] > (c.n - (c.t - i))
+        idxvec[i] += 1
+        if idxvec[i] > (length(c.data) - (c.t - i))
             continue
         end
         for j in i+1:c.t
-            s[j] = s[j-1] + 1
+            idxvec[j] = idxvec[j-1] + 1
         end
         break
     end
-    s[1] > c.n - c.t + 1 && return
-    (s, s)
+    idxvec[1] > length(c.data) - c.t + 1 && return
+    c.data[idxvec], idxvec
 end
 
-Base.length(c::Combinations) = binomial(c.n, c.t)
-
-Base.eltype(::Type{Combinations}) = Vector{Int}
-
 """
-    combinations(a, n)
+    combinations(a, t)
 
-Generate all combinations of `n` elements from an indexable object `a`. Because the number
+Generate all combinations of `t` elements from an indexable object `a`. Because the number
 of combinations can be very large, this function returns an iterator object.
-Use `collect(combinations(a, n))` to get an array of all combinations.
+Use `collect(combinations(a, t))` to get an array of all combinations.
 """
 function combinations(a, t::Integer)
     if t < 0
         # generate 0 combinations for negative argument
         t = length(a) + 1
     end
-    reorder(c) = [a[ci] for ci in c]
-    (reorder(c) for c in Combinations(length(a), t))
+    data = eltype(a)[]
+    sizehint!(data, length(a))
+    for i in eachindex(a)
+        @inbounds push!(data, a[i])
+    end
+    Combinations(data, t)
 end
 
 
@@ -142,8 +153,6 @@ struct MultiSetCombinations{T}
     ref::Vector{Int}
 end
 
-Base.eltype(::Type{MultiSetCombinations{T}}) where {T} = Vector{eltype(T)}
-
 function Base.length(c::MultiSetCombinations)
     t = c.t
     if t > length(c.ref)
@@ -165,9 +174,9 @@ function Base.length(c::MultiSetCombinations)
     return p[t+1]
 end
 
-function multiset_combinations(m, f::Vector{<:Integer}, t::Integer)
+function MultisetCombinations(m, f::Vector{<:Integer}, t::Integer)
     length(m) == length(f) || error("Lengths of m and f are not the same.")
-    ref = length(f) > 0 ? vcat([[i for j in 1:f[i] ] for i in 1:length(f)]...) : Int[]
+    ref = length(f) > 0 ? vcat(fill.(1:length(f), f)...) : Int[]
     if t < 0
         t = length(ref) + 1
     end
@@ -180,40 +189,46 @@ end
 Generate all combinations of size `t` from an array `a` with possibly duplicated elements.
 """
 function multiset_combinations(a, t::Integer)
-    m = unique(collect(a))
-    f = Int[sum([c == x for c in a]) for x in m]
-    multiset_combinations(m, f, t)
+    counts = Dict{eltype(a), Int}()
+    m = eltype(a)[]
+    @inbounds for i in eachindex(a)
+        n = get(counts, a[i], 0) + 1
+        counts[a[i]] = n
+        isone(n) && push!(m, a[i])
+    end
+    f = [counts[key] for key in m]
+    MultisetCombinations(m, f, t)
 end
 
-function Base.iterate(c::MultiSetCombinations, s = c.ref)
+function Base.iterate(c::MultiSetCombinations, s = copy(c.ref))
     ((!isempty(s) && max(s[1], c.t) > length(c.ref)) || (isempty(s) && c.t > 0)) && return
+    nextmultisetcombination!(c.m, c.ref, c.t, s)
+end
 
-    ref = c.ref
+function nextmultisetcombination!(perm, ref, t, idxvec)
     n = length(ref)
-    t = c.t
     changed = false
-    comb = [c.m[s[i]] for i in 1:t]
-    if t > 0
-        s = copy(s)
+    comb = perm[@view idxvec[1:t]]
+    @inbounds if t > 0
         for i in t:-1:1
-            if s[i] < ref[i + (n - t)]
+            if idxvec[i] < ref[i + (n - t)]
                 j = 1
-                while ref[j] <= s[i]
+                while ref[j] ≤ idxvec[i]
                     j += 1
                 end
-                s[i] = ref[j]
+                idxvec[i] = ref[j]
                 for l in (i+1):t
-                    s[l] = ref[j+=1]
+                    idxvec[l] = ref[j+=1]
                 end
                 changed = true
                 break
             end
         end
-        !changed && (s[1] = n+1)
+        changed || (idxvec[1] = n+1)
     else
-        s = [n+1]
+        idxvec = [n+1]
     end
-    (comb, s)
+    (comb, idxvec)
 end
 
 struct WithReplacementCombinations{T}
@@ -234,29 +249,31 @@ with_replacement_combinations(a, t::Integer) = WithReplacementCombinations(a, t)
 
 function Base.iterate(c::WithReplacementCombinations, s = [1 for i in 1:c.t])
     (!isempty(s) && s[1] > length(c.a) || c.t < 0) && return
+    next_wrep_combination!(c.a, c.t, s)
+end
 
-    n = length(c.a)
-    t = c.t
-    comb = [c.a[si] for si in s]
-    if t > 0
-        s = copy(s)
+function next_wrep_combination!(a, t, idxvec)
+    n = length(a)
+    comb = a[idxvec]
+    @inbounds if t > 0
         changed = false
         for i in t:-1:1
-            if s[i] < n
-                s[i] += 1
+            if idxvec[i] < n
+                idxvec[i] += 1
                 for j in (i+1):t
-                    s[j] = s[i]
+                    idxvec[j] = idxvec[i]
                 end
                 changed = true
                 break
             end
         end
-        !changed && (s[1] = n+1)
+        changed || (idxvec[1] = n+1)
     else
-        s = [n+1]
+        idxvec = [n+1]
     end
-    (comb, s)
+    (comb, idxvec)
 end
+
 
 ## Power set
 

--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -13,7 +13,7 @@ end
 function Base.iterate(c::Combinations)
     state = [min(c.t - 1, i) for i in 1:c.t]
     if c.t == 0 # special case to generate 1 result for t==0
-        isempty(state) && return (c.data[state], [1])
+        isempty(state) && return (c.data[state], [length(c.data)+2])
         return
     end
     nextcombination!(c, state)
@@ -245,7 +245,14 @@ Base.length(c::WithReplacementCombinations) = binomial(length(c.a) + c.t - 1, c.
 
 Generate all combinations with replacement of size `t` from an array `a`.
 """
-with_replacement_combinations(a, t::Integer) = WithReplacementCombinations(a, t)
+function with_replacement_combinations(a, t::Integer)
+    data = eltype(a)[]
+    sizehint!(data, length(a))
+    for i in eachindex(a)
+        @inbounds push!(data, a[i])
+    end
+    WithReplacementCombinations(data, t)
+end
 
 function Base.iterate(c::WithReplacementCombinations, s = [1 for i in 1:c.t])
     (!isempty(s) && s[1] > length(c.a) || c.t < 0) && return


### PR DESCRIPTION
This update brings `combinations.jl` in line with the updates to `permuations.jl` in PR #205.

Broadly, this includes:

- Return a `Combinations` iterator, similarly to the other iterators, instead of one wrapped in a `Generator`.
- Mutating the state during iteration, thereby saving memory allocation.

More specifically, the `Combinations` iterator has been made to parallel other implementations in the package, which also eliminates the `state` being returned during iteration (i.e. it now keeps it private to `iterate`). Performance remains largely the same, with just three extra allocations and a very slight drop in running time. This does result in a redefinition of `Combinations` to accept a `Vector` and `Int`, whereas it used to accept an `Int` and `Int`.

The performance boosts have come with changes to `MultiSetCombinations` and `WithReplacementCombinations` mostly with a reduction in allocations by mutating the iteration state (while keeping it private to `iterate`).

An effort was made to standardize the implementations in both `combinations.jl` and `permutations.jl`, so all have similar return values and underlying design for easier maintenance.

<details>
<summary>Benchmarks</summary>

### `multiset_combinations(1:12, 6) |> collect`

**Before**
```julia
BenchmarkTools.Trial: 6124 samples with 1 evaluation per sample.
 Range (min … max):  748.202 μs …   5.619 ms  ┊ GC (min … max): 0.00% … 83.01%
 Time  (median):     772.638 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   811.868 μs ± 205.246 μs  ┊ GC (mean ± σ):  3.21% ±  8.48%

  ██▅▄▄▃▁▁                                                      ▁
  ████████▇▇▇▅▇▅▆▆▄▅▅▅▃▃▁▄▄▄▁▃▄▁▄▁▄▃▃▁▁▁▃▁▃▃▁▁▁▁▁▃▁▁▁▁▃▁▁▅▅▇▇▇▇ █
  748 μs        Histogram: log(frequency) by time          2 ms <

 Memory estimate: 427.17 KiB, allocs estimate: 8935.
```

**After**
```julia
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  29.404 μs …   6.432 ms  ┊ GC (min … max):  0.00% … 98.83%
 Time  (median):     32.010 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   40.272 μs ± 122.507 μs  ┊ GC (mean ± σ):  12.94% ±  5.06%

  ▂▆█▇▇▇▅▅▄▄▄▄▃▂▂▁▁             ▁▂▃▃▂▁▁        ▁▁▁▁            ▂
  ████████████████████▇██▇▇▇▆▆▆▇██████████▇▇▇██████▇█▆▆▇▅▅▅▆▅▆ █
  29.4 μs       Histogram: log(frequency) by time      61.9 μs <

 Memory estimate: 117.20 KiB, allocs estimate: 2029.
```

---

### `multiset_combinations([9, 8, 8, 1, 2, 6, 1, 6, 7, 7, 4, 8], 6) |> collect`

**Before**
```julia
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  130.244 μs …   5.860 ms  ┊ GC (min … max): 0.00% … 96.83%
 Time  (median):     135.780 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   144.084 μs ± 104.581 μs  ┊ GC (mean ± σ):  2.93% ±  4.16%

   █▃  ▅                                                         
  ▅██▅▇██▄▃▃▃▃▃▃▄▆▄▃▄▅▄▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▁▂ ▃
  130 μs           Histogram: frequency by time          189 μs <

 Memory estimate: 79.27 KiB, allocs estimate: 1617.
```

**After**
```julia
BenchmarkTools.Trial: 10000 samples with 5 evaluations per sample.
 Range (min … max):  6.245 μs …  1.447 ms  ┊ GC (min … max):  0.00% … 98.77%
 Time  (median):     6.774 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):   8.525 μs ± 27.436 μs  ┊ GC (mean ± σ):  13.38% ±  4.99%

   ▄▆██▇▆▅▄▄▄▄▃▂▂▁                   ▁▂▂▂▂▁         ▂▂▂▂▁    ▂
  ▇████████████████▇▇█▇▇▆▇▇▆▄▅▅▅▅▃▅▇███████▇▇▅▆▅▅▇████████▇▇ █
  6.24 μs      Histogram: log(frequency) by time     12.1 μs <

 Memory estimate: 24.36 KiB, allocs estimate: 440.
```

---

### `with_replacement_combinations(1:12, 6) |> collect`

**Before**
```julia
BenchmarkTools.Trial: 5882 samples with 1 evaluation per sample.
 Range (min … max):  621.257 μs …   8.156 ms  ┊ GC (min … max):  0.00% … 83.88%
 Time  (median):     660.460 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   846.161 μs ± 627.301 μs  ┊ GC (mean ± σ):  16.47% ± 17.31%

  █▆▅▃▂▁▁                                                       ▁
  ████████████▇▇█▆▄▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▄▅▅▅▅▄▇▆▆▆▇▇▆▇▇▇▆▇▆▇▆▇▆▇▆▅ █
  621 μs        Histogram: log(frequency) by time       3.61 ms <

 Memory estimate: 3.12 MiB, allocs estimate: 61885.
```

**After**
```julia
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  321.837 μs …   6.602 ms  ┊ GC (min … max):  0.00% … 91.76%
 Time  (median):     343.325 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   405.012 μs ± 296.448 μs  ┊ GC (mean ± σ):  12.33% ± 13.97%

  █▆▄▂                                                          ▁
  █████▇▇██▇▇▇▄▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▄▅▆▅▆▆▆▆▆▇▆▆▆▆▅▆▆▆▆▆▆ █
  322 μs        Histogram: log(frequency) by time       2.06 ms <

 Memory estimate: 1.42 MiB, allocs estimate: 24760.
```

---

### `combinations(1:12, 6) |> collect`

**Before**
```julia
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  25.064 μs …   6.588 ms  ┊ GC (min … max):  0.00% … 98.92%
 Time  (median):     31.577 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   43.241 μs ± 135.331 μs  ┊ GC (mean ± σ):  13.15% ±  4.70%

   ▃  ▆█                                                        
  ▃██▅███▄▃▃▃▃▃▃▃▂▃▄▄▄▃▃▃▃▄▃▂▂▂▂▂▂▁▂▁▁▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  25.1 μs         Histogram: frequency by time           83 μs <

 Memory estimate: 108.48 KiB, allocs estimate: 1853.
```

**After**
```julia
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  24.348 μs …   6.947 ms  ┊ GC (min … max):  0.00% … 98.88%
 Time  (median):     28.325 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   36.609 μs ± 129.873 μs  ┊ GC (mean ± σ):  13.48% ±  4.71%

    █▇▂▃▆▅                                                      
  ▂▇██████▇▄▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂ ▃
  24.3 μs         Histogram: frequency by time         63.8 μs <

 Memory estimate: 108.67 KiB, allocs estimate: 1856.
```

</details>

As in PR #205, `multiset_combinations(m, f::Vector{<:Integer}, t::Integer)` has been renamed to `MultisetCombinations(m, f::Vector{<:Integer}, t::Integer)` since this method is not intended to be exported.